### PR TITLE
Switch to Spring Boot 3 / Spring Cloud 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ and for `function`:
 $ mkdir -p tmp/src
 $ cp function/src/main/proto/* tmp/src
 $ cd tmp/src
-$ emcc -I ../include -Os -mmultivalue -Xclang -target-abi -Xclang experimental-mv -s STANDALONE_WASM -s EXPORTED_FUNCTIONS="['_filter']" -Wl,--no-entry message.c message.pb-c.c ../lib/libprotobuf-c.a ../lib/libprotobuf.a -o message.wasm
+$ emcc -I ../include -s ERROR_ON_UNDEFINED_SYMBOLS=0 -Os -s STANDALONE_WASM -s EXPORTED_FUNCTIONS="['_filter','_malloc','_free']" -Wl,--no-entry message.c message.pb-c.c ../lib/libprotobuf-c.a ../lib/libprotobuf.a -o message.wasm
 $ cp message.wasm ../../function/src/main/resources
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,39 @@ bool predicate(uint8_t *data, int len) {
 
 The implementation uses [protobufs](https://developers.google.com/protocol-buffers) to communicate between the JVM and the WASM. This is a pattern that appears in [proxy-wasm](https://github.com/proxy-wasm), a standardization effort for gateway plugins growing out of the implementation in [Envoy](https://www.envoyproxy.io/).
 
+## Pre-requisites
+
+### Protoc
+To build the project you must have `protoc` installed. Execute the following command:
+```shell
+protoc --version
+```
+If installed the output should look like the following:
+```shell
+libprotoc 3.21.5
+```
+If the command is unkown/fails then install `protoc`. For Mac you can run:
+```shell
+brew install protobuf
+```
+
+### Emscripten
+To build the C WASM you will need `emscripten` installed. Execute the following command: 
+```shell
+emcc --version
+```
+If installed the output should look like the following:
+```shell
+emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) 3.1.20-git
+Copyright (C) 2014 the Emscripten authors (see AUTHORS.txt)
+This is free and open source software under the MIT license.
+There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE
+```
+If the command is unkown/fails then install `emscripten`. For Mac you can run:
+```shell
+brew install emscripten
+```
+ 
 ## Playing with JShell
 
 Here's a JShell REPL session that shows how you can play with the WASM module. Start with `./loader.jsh`:

--- a/function/ README.md
+++ b/function/ README.md
@@ -3,8 +3,8 @@
 ### DemoApplication via cURL
 
 ```shell
-curl -v -X POST http://localhost:8080/ \
+curl -v http://localhost:8080/ \
     -H 'Content-type: application/json' \
     -H 'one: two' \
-    -d '{"name": "hello foo"}'
+    -d '{"payload": "hello foo"}'
 ```

--- a/function/ README.md
+++ b/function/ README.md
@@ -1,0 +1,10 @@
+
+
+### DemoApplication via cURL
+
+```shell
+curl -v -X POST http://localhost:8080/ \
+    -H 'Content-type: application/json' \
+    -H 'one: two' \
+    -d '{"name": "hello foo"}'
+```

--- a/function/pom.xml
+++ b/function/pom.xml
@@ -2,21 +2,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.3</version>
-		<relativePath /> <!-- lookup parent from repository -->
+		<groupId>com.example</groupId>
+		<artifactId>spring-wasmtime</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
-	<groupId>com.example</groupId>
 	<artifactId>spring-wasmtime-function-sample</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<name>function-demo</name>
-	<description>Demo project for Spring Boot</description>
+	<name>spring-wasmtime-function-sample</name>
+	<description>Spring Wasmtime Function Sample</description>
+
 	<properties>
-		<java.version>11</java.version>
 		<start-class>com.example.driver.DemoApplication</start-class>
-		<spring-cloud.version>2021.0.1</spring-cloud.version>
 	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
@@ -33,17 +32,6 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>${spring-cloud.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 
 	<build>
 		<plugins>

--- a/function/src/main/proto/message.c
+++ b/function/src/main/proto/message.c
@@ -25,4 +25,4 @@ Wrapper filter(Wrapper input)
     return output;
 }
 
-// $ emcc -I ../include -Os -mmultivalue -Xclang -target-abi -Xclang experimental-mv -s STANDALONE_WASM -s EXPORTED_FUNCTIONS="['_filter']" -Wl,--no-entry message.c ../lib/libprotobuf-c.a ../lib/libprotobuf.a message.pb-c.c -o message.wasm
+// $ emcc -I ../include -s ERROR_ON_UNDEFINED_SYMBOLS=0 -Os -s STANDALONE_WASM -s EXPORTED_FUNCTIONS="['_filter','_malloc','_free']" -Wl,--no-entry message.c message.pb-c.c ../lib/libprotobuf-c.a ../lib/libprotobuf.a -o message.wasm

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -2,21 +2,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.3</version>
-		<relativePath /> <!-- lookup parent from repository -->
+		<groupId>com.example</groupId>
+		<artifactId>spring-wasmtime</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
-	<groupId>com.example</groupId>
 	<artifactId>spring-wasmtime-gateway-sample</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<name>gateway-demo</name>
-	<description>Demo project for Spring Boot</description>
+	<name>spring-wasmtime-gateway-sample</name>
+	<description>Spring Wasmtime Gateway Sample</description>
+
 	<properties>
-		<java.version>11</java.version>
 		<start-class>com.example.driver.DemoApplication</start-class>
-		<spring-cloud.version>2021.0.1</spring-cloud.version>
 	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
@@ -37,17 +36,6 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>${spring-cloud.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 
 	<build>
 		<plugins>

--- a/loader/pom.xml
+++ b/loader/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.3</version>
+		<version>3.0.0-M4</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.springframework.experimental</groupId>
@@ -13,9 +13,8 @@
 	<name>spring-wasm-loader</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
-		<java.version>11</java.version>
+		<java.version>17</java.version>
 		<start-class>com.example.driver.DemoApplication</start-class>
-		<spring-cloud.version>2021.0.1</spring-cloud.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -65,5 +64,65 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<repositories>
+		<repository>
+			<id>spring-snapshots</id>
+			<name>Spring Snapshots</name>
+			<url>https://repo.spring.io/libs-snapshot-local</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
+		<repository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/libs-milestone-local</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<id>spring-releases</id>
+			<name>Spring Releases</name>
+			<url>https://repo.spring.io/release</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>spring-snapshots</id>
+			<name>Spring Snapshots</name>
+			<url>https://repo.spring.io/libs-snapshot-local</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</pluginRepository>
+		<pluginRepository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/libs-milestone-local</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+		<pluginRepository>
+			<id>spring-releases</id>
+			<name>Spring Releases</name>
+			<url>https://repo.spring.io/libs-release-local</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>3.0.0-M4</version>
 	</parent>
 
 	<groupId>com.example</groupId>
@@ -21,32 +21,80 @@
 	</modules>
 
 	<properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
+		<spring-cloud.version>2022.0.0-M4</spring-cloud.version>
+		<cloudevents.version>2.3.0</cloudevents.version>
 	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dependencies</artifactId>
+				<version>${spring-cloud.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<repositories>
 		<repository>
-			<id>spring-libs-snapshot</id>
-			<url>http://repo.spring.io/libs-snapshot</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
+			<id>spring-snapshots</id>
+			<name>Spring Snapshots</name>
+			<url>https://repo.spring.io/libs-snapshot-local</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
+		<repository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/libs-milestone-local</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<id>spring-releases</id>
+			<name>Spring Releases</name>
+			<url>https://repo.spring.io/release</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
 		</repository>
 	</repositories>
-	
+
 	<pluginRepositories>
 		<pluginRepository>
-			<id>spring-libs-snapshot</id>
-			<url>http://repo.spring.io/libs-snapshot</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
+			<id>spring-snapshots</id>
+			<name>Spring Snapshots</name>
+			<url>https://repo.spring.io/libs-snapshot-local</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</pluginRepository>
+		<pluginRepository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/libs-milestone-local</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+		<pluginRepository>
+			<id>spring-releases</id>
+			<name>Spring Releases</name>
+			<url>https://repo.spring.io/libs-release-local</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
 


### PR DESCRIPTION
@dsyer 

This PR updates to Spring Boot 3.0 and Spring Cloud 2022 as well as:

* refactor poms to extract commonality up to parent pom
* update README w/ pre-requisites (protoc , emscrpten)